### PR TITLE
.gitignore and .gitattributes that is VSCODE compatible

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text eol=crlf
+
+*.bmp binary
+*.dbf binary
+*.dll binary
+*.exe binary
+*.ico binary
+*.lib binary
+*.obj binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.bak
+*.ppo
+*.tag
+*.history
+*.code-workspace
+Thumbs.db


### PR DESCRIPTION
Added .gitignore to deal with VSCODE files, and .gitattributes to deal with CRLF and binary files.