### PR TITLE
Fix. Incluye ruta para directiva #include

### DIFF
--- a/samples/curl/test1.prg
+++ b/samples/curl/test1.prg
@@ -10,6 +10,9 @@
 3) Recupera el objeto codificado JSON en aData
 4) Devuelve elemento 1 de la lista 
 ****************************************************************************
+// Necesario -de momento- para que encuentre el fichero include en servidor
+{% hb_SetEnv( "HB_INCLUDE", If( "Linux" $ OS(), "/home/anto/harbour/include", If( "Windows" $ OS(), "c:\harbour\include", "/Users/anto/harbour/include" ) ) ) %}
+//
 */
 #include "hbcurl.ch"
 


### PR DESCRIPTION
Introducción al plugin jsonform, como ejemplo de la interacción entre Javascript y PRG intercambiando JSON y reglas de validacion/presentación. 
Es un ejemplo básico que se ampliará con funcionalidades mas complejas