### PR TITLE
Adding a Dockerfile.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*
+#!linux/Ubuntu*/*harbour.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y apache2
+
+ADD ["linux/Ubuntu 18.04/libharbour.so.3.2.0", "/var/www/html/"]
+ADD ["linux/Ubuntu 18.04/mod_harbour.so", "/usr/lib/apache2/modules/"]
+ADD ["linux/Ubuntu 19.04/mod_harbour.conf", "linux/Ubuntu 19.04/mod_harbour.load", "/root/"]
+
+RUN \
+    # Adding the Apache config.
+    cat /root/mod_harbour.load >> /etc/apache2/apache2.conf && \
+    cat /root/mod_harbour.conf >> /etc/apache2/apache2.conf && \
+    # Changing the path to serve to /var/www/html2 so we can mount a volume in
+    # that folder without worrying about libharbour.so.3.2.0.
+    mkdir /var/www/html2 && \
+    sed -i "s|/var/www/html|/var/www/html2|g" /etc/apache2/sites-enabled/000-default.conf && \
+    # Apache needs the environment variables in /etc/apache2/envvars to be set.
+    echo ". /etc/apache2/envvars && exec /usr/sbin/apache2 -DFOREGROUND" > /root/run_apache.sh && \
+    # Apache expects this folder to exist.
+    mkdir -p /var/run/apache2
+
+EXPOSE 80
+VOLUME /var/www/html2
+
+CMD ["/bin/sh", "/root/run_apache.sh"]

--- a/README.md
+++ b/README.md
@@ -25,3 +25,22 @@ https://harbourproject.slack.com/messages/CJUHF8SBX/
 
 [![](https://bitbucket.org/fivetech/screenshots/downloads/harbour.jpg)](https://harbour.github.io "The Harbour Project")
 <a href="https://httpd.apache.org/" alt="The Apache HTTP Server Project"><img width="150" height="150" src="http://www.apache.org/img/support-apache.jpg"></a>
+
+## Running in Docker
+
+You can also run mod_harbour in a Docker container. You can build the Docker image with:
+
+```sh
+docker build . -t mod_harbour
+```
+
+and then run it with:
+
+```sh
+docker run -p<port>:80 -v"<path>:/var/www/html2:rw,Z" harbour
+```
+
+, for example:
+```sh
+docker run -p3000:80 -v "/home/my_user/mod_harbour/samples:/var/www/html2:rw,Z" harbour
+```


### PR DESCRIPTION
Antonio Linares asked me to put a Dockerfile together for mod_harbour.

The `go.sh` script installs `mysql-server` and `libmysqlclient-dev`, other than `apache2`. Should the Docker container have them installed as well?