### PR TITLE
Fixing .dockerignore and the readme.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
 *
-#!linux/Ubuntu*/*harbour.*
+!linux/Ubuntu*

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ docker build . -t mod_harbour
 and then run it with:
 
 ```sh
-docker run -p<port>:80 -v"<path>:/var/www/html2:rw,Z" harbour
+docker run -p<port>:80 -v"<path>:/var/www/html2:rw,Z" mod_harbour
 ```
 
 , for example:
 ```sh
-docker run -p3000:80 -v "/home/my_user/mod_harbour/samples:/var/www/html2:rw,Z" harbour
+docker run -p3000:80 -v "/home/my_user/mod_harbour/samples:/var/www/html2:rw,Z" mod_harbour
 ```


### PR DESCRIPTION
On my previous pull request (#80) I had commented out the line in the `.gitignore` file to include the linux/Ubuntu folders in the build and I forgot to fix that before pushing. Additionally, the sample commands I added to the readme created an image with the name `mod_harbour`, but then opened an image with the name `harbour`. This commit fixes both issues.