### PR TITLE
Clean up the events that trigger the Github Actions workflows

### DIFF
--- a/.github/workflows/install_win64.yml
+++ b/.github/workflows/install_win64.yml
@@ -2,34 +2,36 @@ name: Windows 64bits installer
 
 on:
   push:
-
-  watch:
-    types: [started]
+    branches:
+      - master
+    paths:
+      - windows/win64/mod_harbour.so
+      - windows/win64/libharbour.dll
+      - windows/win64/setup/modharbour.iss
+      - .github/workflows/install_win64.yml
 
 jobs:
   build:
     runs-on: windows-latest
-    
-    if: github.actor == github.event.repository.owner.login
-    
+
     steps:
-    - name: Checkout mod_harbour repo
-      uses: actions/checkout@v2
-            
-    - name: Build installer
-      run: |
-        iscc windows/win64/setup/modharbour.iss
-        
-    - name: Get current date
-      uses: srfrnk/current-time@master
-      id: current-time
-      with:
-        format: YYYY_MM_DD
- 
-    - name: Building the final zip with the installer inside
-      env:
-         TIME: "${{ steps.current-time.outputs.formattedTime }}"
-      uses: actions/upload-artifact@v2
-      with:
-       name: install_win64_${{ env.TIME }}
-       path: D:\a\mod_harbour\mod_harbour\windows\win64\setup\Output\modharbour.exe        
+      - name: Checkout mod_harbour repo
+        uses: actions/checkout@v2
+
+      - name: Build installer
+        run: |
+          iscc windows/win64/setup/modharbour.iss
+
+      - name: Get current date
+        uses: srfrnk/current-time@master
+        id: current-time
+        with:
+          format: YYYY_MM_DD
+
+      - name: Building the final zip with the installer inside
+        env:
+          TIME: "${{ steps.current-time.outputs.formattedTime }}"
+        uses: actions/upload-artifact@v2
+        with:
+          name: install_win64_${{ env.TIME }}
+          path: D:\a\mod_harbour\mod_harbour\windows\win64\setup\Output\modharbour.exe

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,65 +2,65 @@ name: modharbour for Mac OSX
 
 on:
   push:
-    paths: 
-      - 'apache.prg'
-      - 'mod_harbour.c'
-      - 'osx/modharbour.hbp'
-      - 'osx/mod.hbp'
-  watch:
-   types: [started]
+    branches:
+      - master
+    paths:
+      - apache.prg
+      - mod_harbour.c
+      - osx/modharbour.hbp
+      - osx/mod.hbp
+      - osx/libs.txt
+      - .github/workflows/macos.yml
 
 jobs:
   build:
     runs-on: macos-latest
-    
-    if: github.actor == github.event.repository.owner.login
-    
-    steps:
-    - name: Checkout mod_harbour repo
-      uses: actions/checkout@v2
-    
-    - name: Checkout harbour/core repo
-      uses: actions/checkout@v2
-      with:
-       repository: harbour/core
-       path: harbour
 
-    - name: Install dependencies
-      run: |
-         brew install curl
-         brew install pcre
-         brew install httpd
-         cd osx
-         sed -i '' 's/anto/runner\/runners\/2.169.1\/work\/mod_harbour\/mod_harbour/g' libs.txt
-         
-    - name: Compile Harbour
-      run: |
-        cd harbour
-        export HB_WITH_CURL=/usr/local/Cellar/curl/7.69.1/include/
-        export HB_BUILD_CONTRIBS=""
-        make
-        
-    - name: Compile mod_harbour
-      run: |
-        cd osx
-        ../harbour/bin/darwin/clang/hbmk2 modharbour.hbp
-        mv libmod_harbour.so mod_harbour.so
-        
-    - name: Upload mod_harbour.so to artifact
-      uses: actions/upload-artifact@v2
-      with:
-       name: modharbour_macos_dev
-       path: osx/mod_harbour.so
-       
-    - name: Upload libharbour.so.3.2.0 to artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: modharbour_macos_dev
-        path: osx/libharbour.3.2.0.dylib
-        
-    - name: Upload readme.md to artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: modharbour_macos_dev
-        path: osx/readme.md
+    steps:
+      - name: Checkout mod_harbour repo
+        uses: actions/checkout@v2
+
+      - name: Checkout harbour/core repo
+        uses: actions/checkout@v2
+        with:
+          repository: harbour/core
+          path: harbour
+
+      - name: Install dependencies
+        run: |
+          brew install curl
+          brew install pcre
+          brew install httpd
+          cd osx
+          sed -i '' 's/anto/runner\/runners\/2.169.1\/work\/mod_harbour\/mod_harbour/g' libs.txt
+
+      - name: Compile Harbour
+        run: |
+          cd harbour
+          export HB_WITH_CURL=/usr/local/Cellar/curl/7.69.1/include/
+          export HB_BUILD_CONTRIBS=""
+          make
+
+      - name: Compile mod_harbour
+        run: |
+          cd osx
+          ../harbour/bin/darwin/clang/hbmk2 modharbour.hbp
+          mv libmod_harbour.so mod_harbour.so
+
+      - name: Upload mod_harbour.so to artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: modharbour_macos_dev
+          path: osx/mod_harbour.so
+
+      - name: Upload libharbour.so.3.2.0 to artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: modharbour_macos_dev
+          path: osx/libharbour.3.2.0.dylib
+
+      - name: Upload readme.md to artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: modharbour_macos_dev
+          path: osx/readme.md

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,78 +2,76 @@ name: Ubuntu 64-bits
 
 on:
   push:
-    paths: 
-      - 'apache.prg'
-      - 'mod_harbour.c'
-      - 'linux/modharbour.hbp'
-      - 'linux/mod.hbp'
-      - 'linux/libs.txt'
-      - '.github/workflows/ubuntu.yml'
-  watch:
-   types: [started]
+    branches:
+      - master
+    paths:
+      - apache.prg
+      - mod_harbour.c
+      - linux/modharbour.hbp
+      - linux/mod.hbp
+      - linux/libs.txt
+      - .github/workflows/ubuntu.yml
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    
-    if: github.actor == github.event.repository.owner.login
-    
+
     steps:
-    - name: Checkout mod_harbour repo
-      uses: actions/checkout@v2
-    
-    - name: Checkout harbour/core repo
-      uses: actions/checkout@v2
-      with:
-       repository: harbour/core
-       path: harbour
+      - name: Checkout mod_harbour repo
+        uses: actions/checkout@v2
 
-    - name: Install dependencies
-      run: |
-         sudo apt-get update
-         sudo apt install libcurl4-openssl-dev libssl-dev apache2-dev gcc
-         sudo cp -r /usr/include/x86_64-linux-gnu/curl /usr/include
-         
-    - name: Compile harbour
-      run: |
-        cd harbour
-        export HB_USER_CFLAGS="-fPIC"
-        export HB_BUILD_CONTRIBS
-        export HB_WITH_PCRE=local
-        make
+      - name: Checkout harbour/core repo
+        uses: actions/checkout@v2
+        with:
+          repository: harbour/core
+          path: harbour
 
-    - name: Compile mod_harbour
-      run: |
-        cd linux
-        ../harbour/bin/linux/gcc/hbmk2 modharbour.hbp
-        mv libmod_harbour.so mod_harbour.so
-        
-    - name: Get current time
-      uses: srfrnk/current-time@master
-      id: current-time
-      with:
-        format: YYYY_MM_DD
- 
-    - name: Upload mod_harbour.so to artifact
-      env:
-         TIME: "${{ steps.current-time.outputs.formattedTime }}"
-      uses: actions/upload-artifact@v2
-      with:
-       name: modharbour_ubuntu64_${{ env.TIME }}
-       path: linux/mod_harbour.so
-       
-    - name: Upload libharbour.so.3.2.0 to artifact
-      env:
-         TIME: "${{ steps.current-time.outputs.formattedTime }}"
-      uses: actions/upload-artifact@v2
-      with:
-        name: modharbour_ubuntu64_${{ env.TIME }}
-        path: linux/libharbour.so.3.2.0
-        
-    - name: Upload readme.md to artifact
-      env:
-         TIME: "${{ steps.current-time.outputs.formattedTime }}"
-      uses: actions/upload-artifact@v2
-      with:
-        name: modharbour_ubuntu64_${{ env.TIME }}
-        path: linux/readme.md
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt install libcurl4-openssl-dev libssl-dev apache2-dev gcc
+          sudo cp -r /usr/include/x86_64-linux-gnu/curl /usr/include
+
+      - name: Compile harbour
+        run: |
+          cd harbour
+          export HB_USER_CFLAGS="-fPIC"
+          export HB_BUILD_CONTRIBS
+          export HB_WITH_PCRE=local
+          make
+
+      - name: Compile mod_harbour
+        run: |
+          cd linux
+          ../harbour/bin/linux/gcc/hbmk2 modharbour.hbp
+          mv libmod_harbour.so mod_harbour.so
+
+      - name: Get current time
+        uses: srfrnk/current-time@master
+        id: current-time
+        with:
+          format: YYYY_MM_DD
+
+      - name: Upload mod_harbour.so to artifact
+        env:
+          TIME: "${{ steps.current-time.outputs.formattedTime }}"
+        uses: actions/upload-artifact@v2
+        with:
+          name: modharbour_ubuntu64_${{ env.TIME }}
+          path: linux/mod_harbour.so
+
+      - name: Upload libharbour.so.3.2.0 to artifact
+        env:
+          TIME: "${{ steps.current-time.outputs.formattedTime }}"
+        uses: actions/upload-artifact@v2
+        with:
+          name: modharbour_ubuntu64_${{ env.TIME }}
+          path: linux/libharbour.so.3.2.0
+
+      - name: Upload readme.md to artifact
+        env:
+          TIME: "${{ steps.current-time.outputs.formattedTime }}"
+        uses: actions/upload-artifact@v2
+        with:
+          name: modharbour_ubuntu64_${{ env.TIME }}
+          path: linux/readme.md

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,79 +2,78 @@ name: Windows 64-bits
 
 on:
   push:
-    paths: 
-      - 'apache.prg'
-      - 'mod_harbour.c'
-      - 'windows/modharbour.hbp'
-      - 'windows/mod.hbp'
-  watch:
-   types: [started]
+    branches:
+      - master
+    paths:
+      - apache.prg
+      - mod_harbour.c
+      - windows/modharbour.hbp
+      - windows/mod.hbp
+      - windows/harbour.def
+      - .github/workflows/windows.yml
 
 jobs:
   build:
     runs-on: windows-latest
-    
-    if: github.actor == github.event.repository.owner.login
-    
+
     steps:
-    - uses: actions/checkout@v2
-    
-    - name: Checkout harbour/core repo
-      uses: actions/checkout@v2
-      with:
-       repository: harbour/core
-       path: harbour
+      - uses: actions/checkout@v2
 
-    - name: Install dependencies
-      run: |
-         choco install apache-httpd --params '"/installLocation:C:"'
-         (new-object System.Net.WebClient).DownloadFile('https://bitbucket.org/lorenzodla/mod_harbour_actions_resources/downloads/OpenSSL-Win32.zip', 'C:\temp\OpenSSL-Win32.zip')
-         Expand-Archive -LiteralPath C:\temp\OpenSSL-Win32.zip -DestinationPath C:\OpenSSL -Force
-         (new-object System.Net.WebClient).DownloadFile('https://bitbucket.org/lorenzodla/mod_harbour_actions_resources/downloads/curl-7.54.0-win32-mingw.zip', 'C:\temp\curl-7.54.0-win32-mingw.zip')
-         Expand-Archive -LiteralPath C:\temp\curl-7.54.0-win32-mingw.zip -DestinationPath C:\curl -Force
-         
-    - name: Compile Harbour
-      shell: cmd
-      run: |
-        cd harbour
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
-        set HB_BUILD_MODE=c
-        set HB_USER_PRGFLAGS=-l-
-        set HB_BUILD_CONTRIBS=
-        set HB_WITH_OPENSSL=C:\OpenSSL\include
-        set HB_WITH_CURL=C:\curl\include
-        set HB_COMPILER=msvc64
-        del .\src\common\obj\win\msvc64\hbver.obj
-        del .\src\common\obj\win\msvc64\hbver_dyn.obj
-        del .\src\common\obj\win\msvc64\hbverdsp.obj
-        win-make.exe
-        
-    - name: Compile mod_harbour
-      shell: cmd
-      run: |
-        cd windows
-        set oldpath=%Path%
-        set oldinclude=%INCLUDE%
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
-        ..\harbour\bin\win\msvc64\hbmk2 modharbour.hbp -comp=msvc64 -Lc:\Apache24\lib
-        set Path=%oldpath%
-        set INCLUDE=%oldinclude%
-        
-    - name: Upload mod_harbour.so to artifact
-      uses: actions/upload-artifact@v2
-      with:
-       name: modharbour_win64_dev
-       path: windows/mod_harbour.so
-       
-    - name: Upload libharbour.dll to artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: modharbour_win64_dev
-        path: windows/libharbour.dll
+      - name: Checkout harbour/core repo
+        uses: actions/checkout@v2
+        with:
+          repository: harbour/core
+          path: harbour
 
-    - name: Upload readme.md to artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: modharbour_win64_dev
-        path: windows/readme.md
+      - name: Install dependencies
+        run: |
+          choco install apache-httpd --params '"/installLocation:C:"'
+          (new-object System.Net.WebClient).DownloadFile('https://bitbucket.org/lorenzodla/mod_harbour_actions_resources/downloads/OpenSSL-Win32.zip', 'C:\temp\OpenSSL-Win32.zip')
+          Expand-Archive -LiteralPath C:\temp\OpenSSL-Win32.zip -DestinationPath C:\OpenSSL -Force
+          (new-object System.Net.WebClient).DownloadFile('https://bitbucket.org/lorenzodla/mod_harbour_actions_resources/downloads/curl-7.54.0-win32-mingw.zip', 'C:\temp\curl-7.54.0-win32-mingw.zip')
+          Expand-Archive -LiteralPath C:\temp\curl-7.54.0-win32-mingw.zip -DestinationPath C:\curl -Force
 
+      - name: Compile Harbour
+        shell: cmd
+        run: |
+          cd harbour
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+          set HB_BUILD_MODE=c
+          set HB_USER_PRGFLAGS=-l-
+          set HB_BUILD_CONTRIBS=
+          set HB_WITH_OPENSSL=C:\OpenSSL\include
+          set HB_WITH_CURL=C:\curl\include
+          set HB_COMPILER=msvc64
+          del .\src\common\obj\win\msvc64\hbver.obj
+          del .\src\common\obj\win\msvc64\hbver_dyn.obj
+          del .\src\common\obj\win\msvc64\hbverdsp.obj
+          win-make.exe
+
+      - name: Compile mod_harbour
+        shell: cmd
+        run: |
+          cd windows
+          set oldpath=%Path%
+          set oldinclude=%INCLUDE%
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+          ..\harbour\bin\win\msvc64\hbmk2 modharbour.hbp -comp=msvc64 -Lc:\Apache24\lib
+          set Path=%oldpath%
+          set INCLUDE=%oldinclude%
+
+      - name: Upload mod_harbour.so to artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: modharbour_win64_dev
+          path: windows/mod_harbour.so
+
+      - name: Upload libharbour.dll to artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: modharbour_win64_dev
+          path: windows/libharbour.dll
+
+      - name: Upload readme.md to artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: modharbour_win64_dev
+          path: windows/readme.md

--- a/.github/workflows/windows32.yml
+++ b/.github/workflows/windows32.yml
@@ -2,75 +2,75 @@ name: Windows 32-bits
 
 on:
   push:
-    paths: 
-      - 'apache.prg'
-      - 'mod_harbour.c'
-      - 'windows/modharbour.hbp'
-      - 'windows/mod.hbp'
-  watch:
-   types: [started]
+    branches:
+      - master
+    paths:
+      - apache.prg
+      - mod_harbour.c
+      - windows/modharbour.hbp
+      - windows/mod.hbp
+      - windows/harbour.def
+      - .github/workflows/windows32.yml
 
 jobs:
   build:
     runs-on: windows-latest
-    
-    if: github.actor == github.event.repository.owner.login
-    
+
     steps:
-    - uses: actions/checkout@v2
-    
-    - name: Checkout harbour/core repo
-      uses: actions/checkout@v2
-      with:
-       repository: harbour/core
-       path: harbour
+      - uses: actions/checkout@v2
 
-    - name: Install dependencies
-      run: |
-         choco install apache-httpd --x86 --params '"/installLocation:C:"'
-         (new-object System.Net.WebClient).DownloadFile('https://bitbucket.org/lorenzodla/mod_harbour_actions_resources/downloads/OpenSSL-Win32.zip', 'C:\temp\OpenSSL-Win32.zip')
-         Expand-Archive -LiteralPath C:\temp\OpenSSL-Win32.zip -DestinationPath C:\OpenSSL -Force
-         (new-object System.Net.WebClient).DownloadFile('https://bitbucket.org/lorenzodla/mod_harbour_actions_resources/downloads/curl-7.54.0-win32-mingw.zip', 'C:\temp\curl-7.54.0-win32-mingw.zip')
-         Expand-Archive -LiteralPath C:\temp\curl-7.54.0-win32-mingw.zip -DestinationPath C:\curl -Force
-         
-    - name: Compile Harbour
-      shell: cmd
-      run: |
-        cd harbour
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
-        set HB_BUILD_MODE=c
-        set HB_USER_PRGFLAGS=-l-
-        set HB_BUILD_CONTRIBS=
-        set HB_WITH_OPENSSL=C:\OpenSSL\include
-        set HB_WITH_CURL=C:\curl\include
-        set HB_COMPILER=msvc
-        win-make.exe
-        
-    - name: Compile mod_harbour
-      shell: cmd
-      run: |
-        cd windows
-        set oldpath=%Path%
-        set oldinclude=%INCLUDE%
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
-        ..\harbour\bin\win\msvc\hbmk2 modharbour.hbp -comp=msvc -Lc:\Apache24\lib
-        set Path=%oldpath%
-        set INCLUDE=%oldinclude%
-        
-    - name: Upload mod_harbour.so to artifact
-      uses: actions/upload-artifact@v2
-      with:
-       name: modharbour_win32_dev
-       path: windows/mod_harbour.so
-       
-    - name: Upload libharbour.dll to artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: modharbour_win32_dev
-        path: windows/libharbour.dll
+      - name: Checkout harbour/core repo
+        uses: actions/checkout@v2
+        with:
+          repository: harbour/core
+          path: harbour
 
-    - name: Upload readme.md to artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: modharbour_win32_dev
-        path: windows/readme.md
+      - name: Install dependencies
+        run: |
+          choco install apache-httpd --x86 --params '"/installLocation:C:"'
+          (new-object System.Net.WebClient).DownloadFile('https://bitbucket.org/lorenzodla/mod_harbour_actions_resources/downloads/OpenSSL-Win32.zip', 'C:\temp\OpenSSL-Win32.zip')
+          Expand-Archive -LiteralPath C:\temp\OpenSSL-Win32.zip -DestinationPath C:\OpenSSL -Force
+          (new-object System.Net.WebClient).DownloadFile('https://bitbucket.org/lorenzodla/mod_harbour_actions_resources/downloads/curl-7.54.0-win32-mingw.zip', 'C:\temp\curl-7.54.0-win32-mingw.zip')
+          Expand-Archive -LiteralPath C:\temp\curl-7.54.0-win32-mingw.zip -DestinationPath C:\curl -Force
+
+      - name: Compile Harbour
+        shell: cmd
+        run: |
+          cd harbour
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
+          set HB_BUILD_MODE=c
+          set HB_USER_PRGFLAGS=-l-
+          set HB_BUILD_CONTRIBS=
+          set HB_WITH_OPENSSL=C:\OpenSSL\include
+          set HB_WITH_CURL=C:\curl\include
+          set HB_COMPILER=msvc
+          win-make.exe
+
+      - name: Compile mod_harbour
+        shell: cmd
+        run: |
+          cd windows
+          set oldpath=%Path%
+          set oldinclude=%INCLUDE%
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
+          ..\harbour\bin\win\msvc\hbmk2 modharbour.hbp -comp=msvc -Lc:\Apache24\lib
+          set Path=%oldpath%
+          set INCLUDE=%oldinclude%
+
+      - name: Upload mod_harbour.so to artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: modharbour_win32_dev
+          path: windows/mod_harbour.so
+
+      - name: Upload libharbour.dll to artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: modharbour_win32_dev
+          path: windows/libharbour.dll
+
+      - name: Upload readme.md to artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: modharbour_win32_dev
+          path: windows/readme.md

--- a/.github/workflows/windows32_ads.yml
+++ b/.github/workflows/windows32_ads.yml
@@ -2,81 +2,81 @@ name: Windows 32-bits with ADS
 
 on:
   push:
-    paths: 
-      - 'apache.prg'
-      - 'mod_harbour.c'
-      - 'windows/modharbour.hbp'
-      - 'windows/mod.hbp'
-  watch:
-   types: [started]
+    branches:
+      - master
+    paths:
+      - apache.prg
+      - mod_harbour.c
+      - windows/modharbour.hbp
+      - windows/mod.hbp
+      - windows/harbour.def
+      - .github/workflows/windows32_ads.yml
 
 jobs:
   build:
     runs-on: windows-latest
-    
-    if: github.actor == github.event.repository.owner.login
-    
+
     steps:
-    - uses: actions/checkout@v2
-    
-    - name: Checkout harbour/core repo
-      uses: actions/checkout@v2
-      with:
-       repository: harbour/core
-       path: harbour
+      - uses: actions/checkout@v2
 
-    - name: Install dependencies
-      run: |
-         choco install apache-httpd --x86 --params '"/installLocation:C:"'
-         (new-object System.Net.WebClient).DownloadFile('https://bitbucket.org/lorenzodla/mod_harbour_actions_resources/downloads/OpenSSL-Win32.zip', 'C:\temp\OpenSSL-Win32.zip')
-         Expand-Archive -LiteralPath C:\temp\OpenSSL-Win32.zip -DestinationPath C:\OpenSSL -Force
-         (new-object System.Net.WebClient).DownloadFile('https://bitbucket.org/lorenzodla/mod_harbour_actions_resources/downloads/curl-7.54.0-win32-mingw.zip', 'C:\temp\curl-7.54.0-win32-mingw.zip')
-         Expand-Archive -LiteralPath C:\temp\curl-7.54.0-win32-mingw.zip -DestinationPath C:\curl -Force
-         (new-object System.Net.WebClient).DownloadFile('https://bitbucket.org/lorenzodla/mod_harbour_actions_resources/downloads/acesdk.zip', 'C:\temp\acesdk.zip')
-         Expand-Archive -LiteralPath C:\temp\acesdk.zip -DestinationPath C:\acesdk -Force
-         
-    - name: Compile Harbour
-      shell: cmd
-      run: |
-        cd harbour
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
-        set HB_BUILD_MODE=c
-        set HB_USER_PRGFLAGS=-l-
-        set HB_BUILD_CONTRIBS=
-        set HB_WITH_OPENSSL=C:\OpenSSL\include
-        set HB_WITH_CURL=C:\curl\include
-        set HB_WITH_ADS=C:\acesdk
-        set HB_COMPILER=msvc
-        del .\src\common\obj\win\msvc\hbver.obj
-        del .\src\common\obj\win\msvc\hbver_dyn.obj
-        del .\src\common\obj\win\msvc\hbverdsp.obj
-        win-make.exe
-        
-    - name: Compile mod_harbour
-      shell: cmd
-      run: |
-        cd windows
-        set oldpath=%Path%
-        set oldinclude=%INCLUDE%
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
-        ..\harbour\bin\win\msvc\hbmk2 modharbour.hbp -comp=msvc -Lc:\Apache24\lib -dHB_WITH_ADS="c:\acesdk\" rddads.hbc
-        set Path=%oldpath%
-        set INCLUDE=%oldinclude%
-        
-    - name: Upload mod_harbour.so to artifact
-      uses: actions/upload-artifact@v2
-      with:
-       name: modharbour_win32ads_dev
-       path: windows/mod_harbour.so
-       
-    - name: Upload libharbour.dll to artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: modharbour_win32ads_dev
-        path: windows/libharbour.dll
+      - name: Checkout harbour/core repo
+        uses: actions/checkout@v2
+        with:
+          repository: harbour/core
+          path: harbour
 
-    - name: Upload readme.md to artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: modharbour_win32ads_dev
-        path: windows/readme.md
+      - name: Install dependencies
+        run: |
+          choco install apache-httpd --x86 --params '"/installLocation:C:"'
+          (new-object System.Net.WebClient).DownloadFile('https://bitbucket.org/lorenzodla/mod_harbour_actions_resources/downloads/OpenSSL-Win32.zip', 'C:\temp\OpenSSL-Win32.zip')
+          Expand-Archive -LiteralPath C:\temp\OpenSSL-Win32.zip -DestinationPath C:\OpenSSL -Force
+          (new-object System.Net.WebClient).DownloadFile('https://bitbucket.org/lorenzodla/mod_harbour_actions_resources/downloads/curl-7.54.0-win32-mingw.zip', 'C:\temp\curl-7.54.0-win32-mingw.zip')
+          Expand-Archive -LiteralPath C:\temp\curl-7.54.0-win32-mingw.zip -DestinationPath C:\curl -Force
+          (new-object System.Net.WebClient).DownloadFile('https://bitbucket.org/lorenzodla/mod_harbour_actions_resources/downloads/acesdk.zip', 'C:\temp\acesdk.zip')
+          Expand-Archive -LiteralPath C:\temp\acesdk.zip -DestinationPath C:\acesdk -Force
+
+      - name: Compile Harbour
+        shell: cmd
+        run: |
+          cd harbour
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
+          set HB_BUILD_MODE=c
+          set HB_USER_PRGFLAGS=-l-
+          set HB_BUILD_CONTRIBS=
+          set HB_WITH_OPENSSL=C:\OpenSSL\include
+          set HB_WITH_CURL=C:\curl\include
+          set HB_WITH_ADS=C:\acesdk
+          set HB_COMPILER=msvc
+          del .\src\common\obj\win\msvc\hbver.obj
+          del .\src\common\obj\win\msvc\hbver_dyn.obj
+          del .\src\common\obj\win\msvc\hbverdsp.obj
+          win-make.exe
+
+      - name: Compile mod_harbour
+        shell: cmd
+        run: |
+          cd windows
+          set oldpath=%Path%
+          set oldinclude=%INCLUDE%
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
+          ..\harbour\bin\win\msvc\hbmk2 modharbour.hbp -comp=msvc -Lc:\Apache24\lib -dHB_WITH_ADS="c:\acesdk\" rddads.hbc
+          set Path=%oldpath%
+          set INCLUDE=%oldinclude%
+
+      - name: Upload mod_harbour.so to artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: modharbour_win32ads_dev
+          path: windows/mod_harbour.so
+
+      - name: Upload libharbour.dll to artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: modharbour_win32ads_dev
+          path: windows/libharbour.dll
+
+      - name: Upload readme.md to artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: modharbour_win32ads_dev
+          path: windows/readme.md

--- a/.github/workflows/windows_ads.yml
+++ b/.github/workflows/windows_ads.yml
@@ -2,81 +2,81 @@ name: Windows 64-bits with ADS
 
 on:
   push:
-    paths: 
-      - 'apache.prg'
-      - 'mod_harbour.c'
-      - 'windows/modharbour.hbp'
-      - 'windows/mod.hbp'
-  watch:
-   types: [started]
+    branches:
+      - master
+    paths:
+      - apache.prg
+      - mod_harbour.c
+      - windows/modharbour.hbp
+      - windows/mod.hbp
+      - windows/harbour.def
+      - .github/workflows/windows_ads.yml
 
 jobs:
   build:
     runs-on: windows-latest
-    
-    if: github.actor == github.event.repository.owner.login
-    
+
     steps:
-    - uses: actions/checkout@v2
-    
-    - name: Checkout harbour/core repo
-      uses: actions/checkout@v2
-      with:
-       repository: harbour/core
-       path: harbour
+      - uses: actions/checkout@v2
 
-    - name: Install dependencies
-      run: |
-         choco install apache-httpd --params '"/installLocation:C:"'
-         (new-object System.Net.WebClient).DownloadFile('https://bitbucket.org/lorenzodla/mod_harbour_actions_resources/downloads/OpenSSL-Win32.zip', 'C:\temp\OpenSSL-Win32.zip')
-         Expand-Archive -LiteralPath C:\temp\OpenSSL-Win32.zip -DestinationPath C:\OpenSSL -Force
-         (new-object System.Net.WebClient).DownloadFile('https://bitbucket.org/lorenzodla/mod_harbour_actions_resources/downloads/curl-7.54.0-win32-mingw.zip', 'C:\temp\curl-7.54.0-win32-mingw.zip')
-         Expand-Archive -LiteralPath C:\temp\curl-7.54.0-win32-mingw.zip -DestinationPath C:\curl -Force
-         (new-object System.Net.WebClient).DownloadFile('https://bitbucket.org/lorenzodla/mod_harbour_actions_resources/downloads/acesdk-x64.zip', 'C:\temp\acesdk-x64.zip')
-         Expand-Archive -LiteralPath C:\temp\acesdk-x64.zip -DestinationPath C:\acesdk -Force
-         
-    - name: Compile Harbour
-      shell: cmd
-      run: |
-        cd harbour
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
-        set HB_BUILD_MODE=c
-        set HB_USER_PRGFLAGS=-l-
-        set HB_BUILD_CONTRIBS=
-        set HB_WITH_OPENSSL=C:\OpenSSL\include
-        set HB_WITH_CURL=C:\curl\include
-        set HB_WITH_ADS=C:\acesdk
-        set HB_COMPILER=msvc64
-        del .\src\common\obj\win\msvc64\hbver.obj
-        del .\src\common\obj\win\msvc64\hbver_dyn.obj
-        del .\src\common\obj\win\msvc64\hbverdsp.obj
-        win-make.exe
-        
-    - name: Compile mod_harbour
-      shell: cmd
-      run: |
-        cd windows
-        set oldpath=%Path%
-        set oldinclude=%INCLUDE%
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
-        ..\harbour\bin\win\msvc64\hbmk2 modharbour.hbp -comp=msvc64 -Lc:\Apache24\lib -dHB_WITH_ADS="c:\acesdk\" rddads.hbc
-        set Path=%oldpath%
-        set INCLUDE=%oldinclude%
-        
-    - name: Upload mod_harbour.so to artifact
-      uses: actions/upload-artifact@v2
-      with:
-       name: modharbour_win64ads_dev
-       path: windows/mod_harbour.so
-       
-    - name: Upload libharbour.dll to artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: modharbour_win64ads_dev
-        path: windows/libharbour.dll
+      - name: Checkout harbour/core repo
+        uses: actions/checkout@v2
+        with:
+          repository: harbour/core
+          path: harbour
 
-    - name: Upload readme.md to artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: modharbour_win64ads_dev
-        path: windows/readme.md
+      - name: Install dependencies
+        run: |
+          choco install apache-httpd --params '"/installLocation:C:"'
+          (new-object System.Net.WebClient).DownloadFile('https://bitbucket.org/lorenzodla/mod_harbour_actions_resources/downloads/OpenSSL-Win32.zip', 'C:\temp\OpenSSL-Win32.zip')
+          Expand-Archive -LiteralPath C:\temp\OpenSSL-Win32.zip -DestinationPath C:\OpenSSL -Force
+          (new-object System.Net.WebClient).DownloadFile('https://bitbucket.org/lorenzodla/mod_harbour_actions_resources/downloads/curl-7.54.0-win32-mingw.zip', 'C:\temp\curl-7.54.0-win32-mingw.zip')
+          Expand-Archive -LiteralPath C:\temp\curl-7.54.0-win32-mingw.zip -DestinationPath C:\curl -Force
+          (new-object System.Net.WebClient).DownloadFile('https://bitbucket.org/lorenzodla/mod_harbour_actions_resources/downloads/acesdk-x64.zip', 'C:\temp\acesdk-x64.zip')
+          Expand-Archive -LiteralPath C:\temp\acesdk-x64.zip -DestinationPath C:\acesdk -Force
+
+      - name: Compile Harbour
+        shell: cmd
+        run: |
+          cd harbour
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+          set HB_BUILD_MODE=c
+          set HB_USER_PRGFLAGS=-l-
+          set HB_BUILD_CONTRIBS=
+          set HB_WITH_OPENSSL=C:\OpenSSL\include
+          set HB_WITH_CURL=C:\curl\include
+          set HB_WITH_ADS=C:\acesdk
+          set HB_COMPILER=msvc64
+          del .\src\common\obj\win\msvc64\hbver.obj
+          del .\src\common\obj\win\msvc64\hbver_dyn.obj
+          del .\src\common\obj\win\msvc64\hbverdsp.obj
+          win-make.exe
+
+      - name: Compile mod_harbour
+        shell: cmd
+        run: |
+          cd windows
+          set oldpath=%Path%
+          set oldinclude=%INCLUDE%
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+          ..\harbour\bin\win\msvc64\hbmk2 modharbour.hbp -comp=msvc64 -Lc:\Apache24\lib -dHB_WITH_ADS="c:\acesdk\" rddads.hbc
+          set Path=%oldpath%
+          set INCLUDE=%oldinclude%
+
+      - name: Upload mod_harbour.so to artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: modharbour_win64ads_dev
+          path: windows/mod_harbour.so
+
+      - name: Upload libharbour.dll to artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: modharbour_win64ads_dev
+          path: windows/libharbour.dll
+
+      - name: Upload readme.md to artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: modharbour_win64ads_dev
+          path: windows/readme.md


### PR DESCRIPTION
This change additionally adds the workflow YAML files themselves as paths to match, and removes the restriction that builds can only be triggered by the repository's owner.